### PR TITLE
Add more talks, fit 6 instead of 3 above fold

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,33 +18,87 @@ TODO add this back in when there is content
 
 ## Hear from our engineers
 <!-- 
-  Keep three talks in this section and keep most recent talks at the top.
+  Keep six talks in this section and keep most recent talks at the top.
   As talks are added, shift old talks to the top of the expandable view so that they are also in chronological order from newest to oldest
 -->
+
+<table>
+<tr><td>
+
+### The little SLI that could - [@agirlnamedsophia](https://github.com/agirlnamedsophia)
+[![The little SLI that could link](https://user-images.githubusercontent.com/83998/180072577-65b075b3-e781-4da8-8aaf-8c28a8112da2.png)](https://vimeo.com/730488164)
+
+
+</td><td>
+
+### RAILS_ENV=demo - [@smudge](https://github.com/smudge)
+[![RailsConf 2022 - RAILS_ENV=demo link](https://user-images.githubusercontent.com/83998/180073238-b59f42e5-5c3d-4027-9558-e5a6ad6333fe.png)](https://youtu.be/VibJu9IMohc)
+
+  
+</td></tr>
+<tr><td>
 
 ### Migrating to Flutter the Incremental Way - [@willlockwood](https://github.com/willlockwood)
 [![Migrating to Flutter the Incremental Way link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/migrating-to-flutter-the-incremental-way.png)](https://youtu.be/e6ncTlHSlUE)
 
+</td><td>
+
 ### Offline IoT: Building Resilient Connected Devices without the Internet - [@HipsterBrown](https://github.com/HipsterBrown)
 [![Offline IoT: Building Resilient Connected Devices without the Internet link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/offline-iot-building-resilient-connected-devices-without-the-internet.png)](https://youtu.be/0JROQGWCmds)
 
+</td></tr>
+<tr><td>
+  
 ### Squashing Security Bugs with Rubocop - [@6f6d6172](https://github.com/6f6d6172)
 [![Squashing Security Bugs with Rubocop link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/squashing-security-bugs-with-rubocop.png)](https://youtu.be/aeJIA5oD1tA)
-
-<details>
-<summary>Older talks</summary>
+  
+</td><td>
 
 ### Is Flutter the Coke Zero of the mobile world? - [@yieldjessyield](https://github.com/yieldjessyield) and [@caffeineflo](https://github.com/caffeineflo)
 [![Is Flutter the Coke Zero of the mobile world? link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/is-flutter-the-coke-zero-of-the-mobile-world.png)](https://www.droidcon.com/2021/11/17/is-flutter-the-coke-zero-of-the-mobile-world/)
 
+</td></tr>
+</table>
+
+<details>
+<summary><h3>Even more talks! (:sparkles: click to reveal :sparkles:)</h3></summary>
+
+<table>
+<tr><td>
+
 ### Transforming SwiftUI to JSON (and Vice-Versa) for a fully backend driven UI - [@caffeineflo](https://github.com/caffeineflo)
 [![Transforming SwiftUI to JSON (and Vice-Versa) for a fully backend driven UI link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/transforming-swiftui-to-json-for-a-fully-backend-driven-ui.png)](https://youtu.be/TS2f-DbsJIE)
 
+</td><td>
+  
 ### Can I break this?: Writing resilient "save" methods - [@smudge](https://github.com/smudge)
-[![Can I break this?: Writing resilient "save" methods video link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/can-i-break-this-writing-resilient-save-methods.png)](https://www.youtube.com/watch?v=TuhS13rBoVY)
+[![Can I break this?: Writing resilient "save" methods video link](https://user-images.githubusercontent.com/83998/180075460-7f8b58a3-e49f-47a9-9ef4-08928cbe413c.png)](https://www.youtube.com/watch?v=TuhS13rBoVY)
 
+</td></tr>
+<tr><td>
+  
 ### Transitioning to Flutter at Scale - [@samandmoore](https://github.com/samandmoore)
 [![Transitioning to Flutter at Scale audio link](https://raw.githubusercontent.com/Betterment/.github/main/profile/assets/transitioning-to-flutter-at-scale.png)](https://soundcloud.com/user-910706127/transitioning-to-flutter-at-scale)
+  
+</td><td>
+
+### Hot Swapping Our Rails Front End In Secret - [@chrislopresto](https://github.com/chrislopresto)
+[![Hot Swapping Our Rails Front End In Secret - A Rebrand Story link](https://user-images.githubusercontent.com/83998/180074060-59164fd9-5ede-4015-b7c5-95dd9569f2c3.png)](https://youtu.be/Egumr5KiTNI)
+  
+</td></tr>
+<tr><td>
+
+### Nonconformist Resilience: DB-backed Job Queues - [@jmileham](https://github.com/jmileham)
+[![Nonconformist Resilience: DB-backed Job Queues link](https://user-images.githubusercontent.com/83998/180076579-322821d6-95d1-43c7-bda4-798c5f36d422.jpg)](https://www.infoq.com/presentations/betterment-delayed-job/)
+
+</td><td>
+  
+### Integrate HTTP Services like a Boss - [@samandmoore](https://github.com/samandmoore)
+[![Integrate HTTP Services like a Boss link](https://user-images.githubusercontent.com/83998/180076767-8e165a05-19ca-42c4-a4e2-48659e647c5c.png)](https://youtu.be/Nd9hnffxCP8)
+
+</td></tr>
+</table>
+
 </details>
 
 ## Our open-sourced work


### PR DESCRIPTION
/domain @jonipepin @agirlnamedsophia @CelticMajora 
/no-platform

This does a few things:

1. Adds 5 more talks! Two at the top (from this year) and three more from 2017-2018 below the fold.
2. Makes it so that we show 6 talks above the fold instead of 3. Given that most devs will view this from their laptops/desktops, it felt like we were not making very efficient use of the space. (**We could probably even fit 8 talks above the fold, if we wanted to!**)
3. Changes the hard-to-discover "Older talks" toggle link to a slightly larger "Even more talks! (✨ click to reveal ✨)" toggle.

# Before and After (best viewed on desktop):

<img align="left" width="46%"  src="https://user-images.githubusercontent.com/83998/180077624-58c4968b-8ff6-4446-b5d7-f43432071919.png" />

<img align="right" width="46%" src="https://user-images.githubusercontent.com/83998/180077621-9ba4478e-9696-4ef6-9b32-47f1a331a4a8.png" />



