### PR TITLE
Delete open source projects for now due to errors

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -101,6 +101,15 @@ TODO add this back in when there is content
 
 </details>
 
+## Our open-sourced work
+
+- [test_track](https://github.com/Betterment/test_track)
+- [webvalve](https://github.com/Betterment/webvalve)
+- [delayed](https://github.com/Betterment/delayed) |
+- [better_test_reporter](https://github.com/Betterment/better_test_reporter)
+- [charlatan](https://github.com/Betterment/charlatan)
+- [alchemist](https://github.com/Betterment/alchemist)
+
 ## Tech we use
 ![Ruby on rails](https://img.shields.io/badge/Ruby_on_Rails-CC0000?style=for-the-badge&logo=ruby-on-rails&logoColor=white)
 ![Flutter](https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white)

--- a/profile/README.md
+++ b/profile/README.md
@@ -101,15 +101,6 @@ TODO add this back in when there is content
 
 </details>
 
-## Our open-sourced work
-
-[![test_track](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=test_track)](https://github.com/Betterment/test_track)
-[![webvalve](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=webvalve)](https://github.com/Betterment/webvalve)
-[![delayed](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=delayed)](https://github.com/Betterment/delayed)
-[![better_test_reporter](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=better_test_reporter)](https://github.com/Betterment/better_test_reporter)
-[![charlatan](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=charlatan)](https://github.com/Betterment/charlatan)
-[![alchemist](https://github-readme-stats.vercel.app/api/pin/?username=Betterment&repo=alchemist)](https://github.com/Betterment/alchemist)
-
 ## Tech we use
 ![Ruby on rails](https://img.shields.io/badge/Ruby_on_Rails-CC0000?style=for-the-badge&logo=ruby-on-rails&logoColor=white)
 ![Flutter](https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white)

--- a/profile/README.md
+++ b/profile/README.md
@@ -105,7 +105,7 @@ TODO add this back in when there is content
 
 - [test_track](https://github.com/Betterment/test_track)
 - [webvalve](https://github.com/Betterment/webvalve)
-- [delayed](https://github.com/Betterment/delayed) |
+- [delayed](https://github.com/Betterment/delayed)
 - [better_test_reporter](https://github.com/Betterment/better_test_reporter)
 - [charlatan](https://github.com/Betterment/charlatan)
 - [alchemist](https://github.com/Betterment/alchemist)


### PR DESCRIPTION
Seeing this:

![Screen Shot 2023-01-19 at 11 15 39 AM](https://user-images.githubusercontent.com/83998/213497634-67d0e6a9-da39-4241-a841-9cc07c0be22f.png)

I don't think we want to try to host something ourselves. The "popular repositories" list is right below this on the page, and if we wanted to call anything else out I'd propose circling back with a markdown-based list of repos, perhaps using a markdown table for multiple columns.